### PR TITLE
fix: dark mode toggle

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ const { wsCache } = useCache()
 
 // 根据浏览器当前主题设置系统主题色
 const setDefaultTheme = () => {
-  if (wsCache.get('isDark')) {
+  if (wsCache.get('isDark') !== null) {
     appStore.setIsDark(wsCache.get('isDark'))
     return
   }


### PR DESCRIPTION
if isDark is set to false, it will jump this judgement and use the system prefers 

if isDark is not set to wsCache it will return null by default