### PR TITLE
fix: 修改 Editor 的 z-index 使其不会遮挡『综合示例 - 新增』界面的下拉菜单

### DIFF
--- a/src/api/login/index.ts
+++ b/src/api/login/index.ts
@@ -18,8 +18,8 @@ export const getUserListApi = ({ params }: AxiosConfig) => {
     code: string
     data: {
       list: UserType[]
-      total: number 
-    }   
+      total: number
+    }
   }>({ url: '/user/list', params })
 }
 

--- a/src/components/Editor/src/Editor.vue
+++ b/src/components/Editor/src/Editor.vue
@@ -116,7 +116,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="border-1 border-solid border-[var(--tags-view-border-color)] z-3000">
+  <div class="border-1 border-solid border-[var(--tags-view-border-color)] z-99">
     <!-- 工具栏 -->
     <Toolbar
       :editor="editorRef"


### PR DESCRIPTION
- 修改 Editor 的 z-index 为 99，使其不会遮挡『综合示例 - 新增』界面的下拉菜单（z-index 最小值为 2008），同时保证不会遮挡顶部的『新增』栏（z-index 值为 999）
- 删除 `src/api/login/index.ts` 文件多余的空格