### PR TITLE
fix: 修复表格与搜索框字段不能不一致的问题

### DIFF
--- a/src/hooks/web/useCrudSchemas.ts
+++ b/src/hooks/web/useCrudSchemas.ts
@@ -23,6 +23,8 @@ type CrudSearchParams = {
   dictName?: string
   // 接口
   api?: () => Promise<any>
+  // 搜索字段
+  field?: string
 } & Omit<FormSchema, 'field'>
 
 type CrudTableParams = {
@@ -101,7 +103,7 @@ const filterSearchSchema = (crudSchema: CrudSchema[], allSchemas: AllSchemas): F
         component: schemaItem.search.component || 'Input',
         componentProps: {},
         ...schemaItem.search,
-        field: schemaItem.field,
+        field: schemaItem?.search?.field || schemaItem.field,
         label: schemaItem.search?.label || schemaItem.label
       }
 


### PR DESCRIPTION
* fix: 修复表格与搜索框字段不能不一致的问题
  比如：后台返回数据的字段是{"id":1,"username":"张三"...}，而搜索的时候要传的参数不是username，而是name。