### PR TITLE
fix: 使用动态路由时，多级路由只有一个子路且父路由未使用alwaysShow时，子路由未添加至路由中

### DIFF
--- a/src/utils/routerHelper.ts
+++ b/src/utils/routerHelper.ts
@@ -70,7 +70,7 @@ export const generateRoutesFn1 = (
       if (isUrl(item) && (onlyOneChild === item || route.path === item)) {
         data = Object.assign({}, route)
       } else {
-        const routePath = pathResolve(basePath, onlyOneChild || route.path)
+        const routePath = onlyOneChild ?? pathResolve(basePath, route.path)
         if (routePath === item || meta.followRoute === item) {
           data = Object.assign({}, route)
         }


### PR DESCRIPTION
onlyOneChild已经是pathResolve处理后的结果了，多层级时，再使用basePath和onlyOneChild生成routePath错误，会出现路径重复（/level/menu1/level/menu1/menu1-1/menu1-1-1），会导致“level/menu1/menu1-1/menu1-1-1”路由丢失