### PR TITLE
fix: expand clickable area of collapse-icon

### DIFF
--- a/src/components/Collapse/src/Collapse.vue
+++ b/src/components/Collapse/src/Collapse.vue
@@ -23,13 +23,12 @@ const toggleCollapse = () => {
 </script>
 
 <template>
-  <div :class="prefixCls">
+  <div :class="prefixCls" @click="toggleCollapse">
     <Icon
       :size="18"
       :icon="collapse ? 'ant-design:menu-unfold-outlined' : 'ant-design:menu-fold-outlined'"
       :color="color"
       class="cursor-pointer"
-      @click="toggleCollapse"
     />
   </div>
 </template>


### PR DESCRIPTION
扩大 collapse-icon 的可点击区域，修复部分区域点击无效的问题。