### PR TITLE
fect: 表格工具栏新增列设置功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "vue-i18n": "9.2.2",
     "vue-json-pretty": "^2.2.4",
     "vue-router": "^4.2.4",
-    "vue-types": "^5.1.1"
+    "vue-types": "^5.1.1",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.7.1",
@@ -83,6 +84,7 @@
     "husky": "^8.0.3",
     "less": "^4.2.0",
     "lint-staged": "^13.2.3",
+    "lodash": "^4.17.21",
     "plop": "^3.1.2",
     "postcss": "^8.4.27",
     "postcss-html": "^1.5.0",

--- a/src/components/Table/src/types/index.ts
+++ b/src/components/Table/src/types/index.ts
@@ -4,9 +4,9 @@ export interface TableColumn {
   label?: string
   type?: string
   /**
-   * 是否隐藏
+   * 是否显示，必填
    */
-  hidden?: boolean
+  show: boolean
   children?: TableColumn[]
   slots?: {
     default?: (...args: any[]) => JSX.Element | JSX.Element[] | null


### PR DESCRIPTION
在表格工具栏中新加入列设置功能，列设置支持拖拽排序，一键全选/全不选，重置列，展示隐藏列功能

并在表格工具栏行加入插槽，可以在同行加入按钮等组件

实现图：

![image](https://github.com/kailong321200875/vue-element-plus-admin/assets/108704266/1373969f-f035-49a7-b195-727f5e9aedbe)
