### PR TITLE
fix(Descriptions): Add a default value

### DIFF
--- a/src/components/Descriptions/src/Descriptions.vue
+++ b/src/components/Descriptions/src/Descriptions.vue
@@ -16,6 +16,8 @@ const { getPrefixCls } = useDesign()
 
 const prefixCls = getPrefixCls('descriptions')
 
+const defaultData = '-'
+
 export default defineComponent({
   name: 'Descriptions',
   props: {
@@ -115,7 +117,7 @@ export default defineComponent({
                             default: () =>
                               item.slots?.default
                                 ? item.slots?.default(props.data)
-                                : get(props.data, item.field)
+                                : get(props.data, item.field) ?? defaultData
                           }}
                         </ElDescriptionsItem>
                       )


### PR DESCRIPTION
Set a default value for the Descriptions component. Use the uniform default value when ElDescriptionsItem value does not exist
详情组件设置一个默认值，当 ElDescriptionsItem 的value不存在时使用统一的默认值