### PR TITLE
fix: 表单布局方式为top时，查询组件按钮位置错位

### DIFF
--- a/src/components/Search/src/Search.vue
+++ b/src/components/Search/src/Search.vue
@@ -88,6 +88,9 @@ const newSchema = computed(() => {
                   />
                 </div>
               )
+            },
+            label: () => {
+              return <span>&nbsp;</span>
             }
           }
         }


### PR DESCRIPTION
![image](https://github.com/kailong321200875/vue-element-plus-admin/assets/73596755/be047b4c-1b15-476e-b721-ca1819548563)

![image](https://github.com/kailong321200875/vue-element-plus-admin/assets/73596755/f31bc200-0040-440a-a495-5456dd70ee04)
