### PR TITLE
fix:  修复cutMenu布局和top布局内容高度计算错误问题

### DIFF
--- a/src/layout/components/AppView.vue
+++ b/src/layout/components/AppView.vue
@@ -44,10 +44,10 @@ const tagsView = computed(() => appStore.getTagsView)
         // '!min-h-[calc(100%-var(--app-content-padding)-var(--app-content-padding)-var(--app-footer-height)-var(--tags-view-height)-var(--top-tool-height))]':
         //   !fixedHeader && layout === 'top' && footer,
 
-        '!min-h-[calc(100%-var(--top-tool-height)-var(--app-content-padding)-var(--app-content-padding))]':
+        '!min-h-[calc(100%-var(--app-footer-height)-var(--app-content-padding)-var(--app-content-padding))]':
           fixedHeader && layout === 'cutMenu' && footer,
 
-        '!min-h-[calc(100%-var(--top-tool-height)-var(--app-content-padding)-var(--app-content-padding)-var(--tags-view-height))]':
+        '!min-h-[calc(100%-var(--app-footer-height)-var(--app-content-padding)-var(--app-content-padding)-var(--tags-view-height))]':
           !fixedHeader && layout === 'cutMenu' && footer
       }
     ]"

--- a/src/layout/components/useRenderLayout.tsx
+++ b/src/layout/components/useRenderLayout.tsx
@@ -195,8 +195,8 @@ export const useRenderLayout = () => {
             `${prefixCls}-content`,
             'w-full',
             {
-              'h-[calc(100%-var(--app-footer-height))]': !fixedHeader.value,
-              'h-[calc(100%-var(--tags-view-height)-var(--app-footer-height))]': fixedHeader.value
+              'h-[calc(100%-var(--top-tool-height))]': !fixedHeader.value,
+              'h-[calc(100%-var(--tags-view-height)-var(--top-tool-height))]': fixedHeader.value
             }
           ]}
         >


### PR DESCRIPTION
cutMenu布局和top布局内容高度计算错误，可修改--logo-height值为100px 复现相关问题，此前无问题因为
--logo-height和--app-footer-height同为50px所以计算结果一样，显示看不出问题