### PR TITLE
fix: Menu菜单组件显示bug，renderMenuItem返回的数组存在undefined数据，导致省略菜单显示问题

### DIFF
--- a/src/components/Menu/src/components/useRenderMenuItem.tsx
+++ b/src/components/Menu/src/components/useRenderMenuItem.tsx
@@ -12,9 +12,10 @@ export const useRenderMenuItem = (
   menuMode: 'vertical' | 'horizontal'
 ) => {
   const renderMenuItem = (routers: AppRouteRecordRaw[], parentPath = '/') => {
-    return routers.map((v) => {
-      const meta = v.meta ?? {}
-      if (!meta.hidden) {
+    return routers
+      .filter((v) => !v.meta?.hidden)
+      .map((v) => {
+        const meta = v.meta ?? {}
         const { oneShowingChild, onlyOneChild } = hasOneShowingChild(v.children, v)
         const fullPath = isUrl(v.path) ? v.path : pathResolve(parentPath, v.path) // getAllParentPath<AppRouteRecordRaw>(allRouters, v.path).join('/')
 
@@ -48,8 +49,7 @@ export const useRenderMenuItem = (
             </ElSubMenu>
           )
         }
-      }
-    })
+      })
   }
 
   return {


### PR DESCRIPTION
![image](https://github.com/kailong321200875/vue-element-plus-admin/assets/50280059/063e12e0-b1b2-4222-a604-48c7c1fb883d)
在屏幕宽度1560左右可复现此问题，经排查renderMenuItem返回的数组存在undefined项，过滤去除后菜单显示恢复正常