### PR TITLE
fix: Table组件设置 align="center" 导致横向滚动条位置错误问题

### DIFF
--- a/src/components/Table/src/Table.vue
+++ b/src/components/Table/src/Table.vue
@@ -339,6 +339,7 @@ export default defineComponent({
       const bindValue: Recordable = { ...attrs, ...unref(getProps) }
       delete bindValue.columns
       delete bindValue.data
+      delete bindValue.align
       return bindValue
     })
 


### PR DESCRIPTION
1、element-plus的el-table组件设置文档中并无align属性说明
2、el-table组件设置 align="center" 会导致横向滚动条位置错误（内容已是最左侧，但是滚动条未靠最左侧）
![image](https://github.com/kailong321200875/vue-element-plus-admin/assets/50280059/f7517bf3-f3fa-475c-92b5-51042bbd176b)



