### PR TITLE
fix: 修复请求示例中，mock开启时无法取消单个请求的问题

### DIFF
--- a/src/axios/service.ts
+++ b/src/axios/service.ts
@@ -18,7 +18,7 @@ axiosInstance.interceptors.request.use((res: InternalAxiosRequestConfig) => {
   const controller = new AbortController()
   const url = res.url || ''
   res.signal = controller.signal
-  abortControllerMap.set(url, controller)
+  abortControllerMap.set(import.meta.env.VITE_USE_MOCK ? url.replace('/mock', '') : url, controller)
   return res
 })
 

--- a/src/axios/service.ts
+++ b/src/axios/service.ts
@@ -18,7 +18,7 @@ axiosInstance.interceptors.request.use((res: InternalAxiosRequestConfig) => {
   const controller = new AbortController()
   const url = res.url || ''
   res.signal = controller.signal
-  abortControllerMap.set(import.meta.env.VITE_USE_MOCK ? url.replace('/mock', '') : url, controller)
+  abortControllerMap.set(import.meta.env.VITE_USE_MOCK === 'true' ? url.replace('/mock', '') : url, controller)
   return res
 })
 


### PR DESCRIPTION
菜单：功能 => 请求
mock 模式下无法取消单个请求