### PR TITLE
fix: 修复 prettier 报错

### DIFF
--- a/src/axios/service.ts
+++ b/src/axios/service.ts
@@ -18,7 +18,10 @@ axiosInstance.interceptors.request.use((res: InternalAxiosRequestConfig) => {
   const controller = new AbortController()
   const url = res.url || ''
   res.signal = controller.signal
-  abortControllerMap.set(import.meta.env.VITE_USE_MOCK === 'true' ? url.replace('/mock', '') : url, controller)
+  abortControllerMap.set(
+    import.meta.env.VITE_USE_MOCK === 'true' ? url.replace('/mock', '') : url,
+    controller
+  )
   return res
 })
 


### PR DESCRIPTION
修复 axios => service 文件未运行 lint:format 命令导致的 prettier 报错问题
