### PR TITLE
feat: add vite-plugin-url-copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "vite-plugin-purge-icons": "^0.10.0",
     "vite-plugin-style-import": "2.0.0",
     "vite-plugin-svg-icons": "^2.0.1",
+    "vite-plugin-url-copy": "^1.1.1",
     "vue-tsc": "^1.8.27"
   },
   "packageManager": "pnpm@8.1.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import EslintPlugin from 'vite-plugin-eslint'
 import { ViteEjsPlugin } from 'vite-plugin-ejs'
 import { viteMockServe } from 'vite-plugin-mock'
 import PurgeIcons from 'vite-plugin-purge-icons'
+import ServerUrlCopy from 'vite-plugin-url-copy'
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
 import { createSvgIconsPlugin } from 'vite-plugin-svg-icons'
 import { createStyleImportPlugin, ElementPlusResolve } from 'vite-plugin-style-import'
@@ -39,6 +40,7 @@ export default ({ command, mode }: ConfigEnv): UserConfig => {
         }
       }),
       VueJsx(),
+      ServerUrlCopy(),
       progress(),
       env.VITE_USE_ALL_ELEMENT_PLUS_STYLE === 'false'
         ? createStyleImportPlugin({


### PR DESCRIPTION
**[vite-plugin-url-copy](https://www.npmjs.com/package/vite-plugin-url-copy)**

自动复制 Vite 服务器 URL 并生成二维码，方便开发或预览期访问.
支持复制服务器 URL (local and network).
支持生成网络URL二维码.

<img width="728" alt="image" src="https://github.com/kailong321200875/vue-element-plus-admin/assets/114689629/f459988b-0b9c-4dec-9146-6ad7d78efb34">
