### PR TITLE
fix: Table组件注册为全局组件报错问题，存在对pinia的提前引用

### DIFF
--- a/src/components/Table/src/components/TableActions.vue
+++ b/src/components/Table/src/components/TableActions.vue
@@ -7,11 +7,6 @@ import { useAppStore } from '@/store/modules/app'
 import { TableColumn } from '../types'
 import ColumnSetting from './ColumnSetting.vue'
 
-const appStore = useAppStore()
-const sizeMap = computed(() => appStore.sizeMap)
-
-const { t } = useI18n()
-
 export default defineComponent({
   name: 'TableActions',
   components: {
@@ -25,6 +20,9 @@ export default defineComponent({
   },
   emits: ['refresh', 'changSize', 'confirm'],
   setup(props, { emit }) {
+    const appStore = useAppStore()
+    const { t } = useI18n()
+    const sizeMap = computed(() => appStore.sizeMap)
     const showSetting = ref(false)
 
     const refresh = () => {


### PR DESCRIPTION
目前写法Table无法注册为全局组件，pinia存在提前引用，当注册为全局组件时会报如下错误
![image](https://github.com/kailong321200875/vue-element-plus-admin/assets/50280059/ccdd9b91-67bc-47ea-aee5-c9da7ddad525)

所以将相关的useAppStore和useI18n写入到setup内部