### PR TITLE
fix: 修复 lint-staged 中 prettier 以 json 格式美化代码的无效命令问题

### DIFF
--- a/.husky/lintstagedrc.js
+++ b/.husky/lintstagedrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   '*.{js,jsx,ts,tsx}': ['eslint --fix', 'prettier --write'],
-  '{!(package)*.json,*.code-snippets,.!(browserslist)*rc}': ['prettier --write--parser json'],
+  '{!(package)*.json,*.code-snippets,.!(browserslist)*rc}': ['prettier --parser json --write'],
   'package.json': ['prettier --write'],
   '*.vue': ['prettier --write', 'stylelint --fix'],
   '*.{scss,less,styl,css,html}': ['stylelint --fix', 'prettier --write'],


### PR DESCRIPTION
--write 与 --parser 应存在空格