### PR TITLE
fix: 修复 Transfer 组件 optionApi 不生效

### DIFF
--- a/src/components/Form/src/Form.vue
+++ b/src/components/Form/src/Form.vue
@@ -158,7 +158,8 @@ export default defineComponent({
         {
           field: item.field,
           path:
-            item.component === ComponentNameEnum.TREE_SELECT
+            item.component === ComponentNameEnum.TREE_SELECT ||
+            item.component === ComponentNameEnum.TRANSFER
               ? 'componentProps.data'
               : 'componentProps.options',
           value: options


### PR DESCRIPTION
Transfer 组件绑定选项值也是 data, 但是Form 组件里只针对 TreeSelect 做了处理, 除了TreeSelect 都赋值给了options,  所以加上 Transfer 的判断

