### PR TITLE
fix: 修复 search组件的收起展开 和重置 Bug  #441

### DIFF
--- a/src/components/Form/src/Form.vue
+++ b/src/components/Form/src/Form.vue
@@ -231,7 +231,7 @@ export default defineComponent({
       const { schema = [], isCol } = unref(getProps)
 
       return schema
-        .filter((v) => !v.remove && !v.hidden)
+        .filter((v) => !v.remove)
         .map((item) => {
           // 如果是 Divider 组件，需要自己占用一行
           const isDivider = item.component === 'Divider'


### PR DESCRIPTION
renderFormItemWrap 中将 hidden的给过滤了, 所以 renderFormItem 中其实并没有对 hidden 的 FormItem 生效, 所以出现了Bug

具体element-plus  Issues参考 https://github.com/element-plus/element-plus/issues/15417