### PR TITLE
fix: 左侧菜单收起后，组件菜单的子菜单显示不全

### DIFF
--- a/src/components/Menu/src/Menu.vue
+++ b/src/components/Menu/src/Menu.vue
@@ -98,7 +98,7 @@ export default defineComponent({
         >
           {{
             default: () => {
-              const { renderMenuItem } = useRenderMenuItem()
+              const { renderMenuItem } = useRenderMenuItem(menuMode)
               return renderMenuItem(unref(routers))
             }
           }}
@@ -256,5 +256,10 @@ export default defineComponent({
       background-color: var(--left-menu-bg-active-color) !important;
     }
   }
+}
+@submenu-prefix-cls: ~'@{adminNamespace}-submenu-popper';
+.@{submenu-prefix-cls}--vertical {
+  overflow-y: auto;
+  max-height: 100%;
 }
 </style>

--- a/src/components/Menu/src/components/useRenderMenuItem.tsx
+++ b/src/components/Menu/src/components/useRenderMenuItem.tsx
@@ -1,12 +1,17 @@
 import { ElSubMenu, ElMenuItem } from 'element-plus'
+import { unref } from 'vue'
 import { hasOneShowingChild } from '../helper'
 import { isUrl } from '@/utils/is'
 import { useRenderMenuTitle } from './useRenderMenuTitle'
 import { pathResolve } from '@/utils/routerHelper'
+import { useDesign } from '@/hooks/web/useDesign'
+
+const { getPrefixCls } = useDesign()
+const prefixCls = getPrefixCls('submenu')
 
 const { renderMenuTitle } = useRenderMenuTitle()
 
-export const useRenderMenuItem = () =>
+export const useRenderMenuItem = (menuMode) =>
   // allRouters: AppRouteRecordRaw[] = [],
   {
     const renderMenuItem = (routers: AppRouteRecordRaw[], parentPath = '/') => {
@@ -33,7 +38,11 @@ export const useRenderMenuItem = () =>
             )
           } else {
             return (
-              <ElSubMenu index={fullPath}>
+              <ElSubMenu
+                index={fullPath}
+                popper-append-to-body
+                popperClass={unref(menuMode) === 'vertical' ? `${prefixCls}-popper--vertical` : ''}
+              >
                 {{
                   title: () => renderMenuTitle(meta),
                   default: () => renderMenuItem(v.children!, fullPath)


### PR DESCRIPTION
修改前：
![image](https://github.com/kailong321200875/vue-element-plus-admin/assets/29885006/a0499c97-aca4-4373-bed1-b1afbd71f032)
修改后：
![image](https://github.com/kailong321200875/vue-element-plus-admin/assets/29885006/88380611-3e20-4dd3-8d28-9e2e27346c68)
