### PR TITLE
fix: initModel判断schema对应的field是否存在,兼容null与0等场景

### DIFF
--- a/src/components/Form/src/helper/index.ts
+++ b/src/components/Form/src/helper/index.ts
@@ -161,7 +161,7 @@ export const initModel = (schema: FormSchema[], formModel: Recordable) => {
   // 如果 schema 对应的 field 不存在，则删除 model 中的对应的 field
   for (let i = 0; i < schema.length; i++) {
     const key = schema[i].field
-    if (!get(model, key) && get(model, key) !== 0) {
+    if (!model.hasOwnProperty(key)) {
       delete model[key]
     }
   }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0b1c111f-8298-480e-b015-fcf28fe416c2)
这里的if判断，如果只是判断schema对应的field,在model对象的key中是否存在，建议用!model.hasOwnProperty(key)判断
不应该用目前的get方法通过值判断，目前通过get获取的对象value值判断 也无法兼容null的场景，会误删掉