### PR TITLE
fix: 修复工作流变量名称错误导致自动合并失败

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -25,7 +25,7 @@ jobs:
         uses: 'pascalgn/automerge-action@v0.14.3'
         env:
           BASE_BRANCHES: 'release'
-          GITHUB_TOKEN: '${{ secrets.TOKEN }}'
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           MERGE_LABELS: ''
           MERGE_FILTER_AUTHOR: 'kailong321200875'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: GoogleCloudPlatform/release-please-action@v3
         id: release
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN  }}
           default-branch: release
           release-type: node
           package-name: standard-version


### PR DESCRIPTION
github提交auto merge 失败, 可能是由于官方将原有常量secrets.TOKEN改为了secrets.GITHUB_TOKEN