### PR TITLE
fix: 修复表格列设置弹窗出现警告问题

### DIFF
--- a/src/components/Table/src/components/ColumnSetting.vue
+++ b/src/components/Table/src/components/ColumnSetting.vue
@@ -51,7 +51,7 @@ const confirm = () => {
   const newColumns = cloneDeep(unref(settingColumns))?.map((item) => {
     const fixed = unref(settingColumns)?.find((col) => col.field === item.field)?.fixed
     item.hidden = !unref(checkColumns)?.includes(item.field)
-    item.fixed = fixed ? fixed : undefined
+    item.fixed = fixed ? fixed : false
     return item
   })
   emit('confirm', [...unref(hiddenColumns), ...(newColumns || [])])
@@ -65,7 +65,7 @@ const restore = () => {
 const initColumns = (columns: TableColumn[], isReStore = false) => {
   const newColumns = columns?.filter((item) => {
     if (!isReStore) {
-      item.fixed = item.fixed !== void 0 ? item.fixed : undefined
+      item.fixed = item.fixed !== void 0 ? item.fixed : false
     }
     return (item.type && !DEFAULT_FILTER_COLUMN.includes(item.type)) || !item.type
   })
@@ -133,18 +133,18 @@ watch(
               :key="item.field"
               class="flex items-center justify-between mt-12px"
             >
-              <ElCheckbox :label="item.field">
+              <ElCheckbox :value="item.field">
                 {{ item.label }}
               </ElCheckbox>
               <div class="flex items-center">
                 <ElRadioGroup size="small" v-model="item.fixed">
-                  <ElRadioButton label="left">
+                  <ElRadioButton value="left">
                     <Icon icon="vi-ep:arrow-left" />
                   </ElRadioButton>
-                  <ElRadioButton :label="undefined">
+                  <ElRadioButton :value="false">
                     <Icon icon="vi-ep:close" />
                   </ElRadioButton>
-                  <ElRadioButton label="right">
+                  <ElRadioButton value="right">
                     <Icon icon="vi-ep:arrow-right" />
                   </ElRadioButton>
                 </ElRadioGroup>


### PR DESCRIPTION
打开设置列弹窗会出现警告, 原因是ElRadioButton组件在3.0后会废弃label改用value绑定值, 且ElRadioGroup绑定的fixed值不能是undefined