### PR TITLE
fix: IconPicker.vue

### DIFF
--- a/src/components/IconPicker/src/IconPicker.vue
+++ b/src/components/IconPicker/src/IconPicker.vue
@@ -171,7 +171,7 @@ const inputClear = () => {
           v-model:current-page="currentPage"
           v-model:page-size="pageSize"
           :pager-count="5"
-          small
+          size="small"
           :page-sizes="[100, 200, 300, 400]"
           layout="total, prev, pager, next, jumper"
           :total="filterItemIcons(icons[currentIconNameIndex].icons).length"


### PR DESCRIPTION
fix: ElementPlusError: [el-pagination] [API] small is about to be deprecated in version 3.0.0, please use size instead.