### PR TITLE
.1502411993651747:69a2c4e772263d32d0f9bf4f9d741e45_69ef661c07d6136ac82f822c.69eff21407d6136ac82f8413.69eff214687f81664842ed24:Trae CN.T(2026/4/28 07:32:36)

### DIFF
--- a/src/components/LocaleDropdown/src/LocaleDropdown.vue
+++ b/src/components/LocaleDropdown/src/LocaleDropdown.vue
@@ -22,11 +22,6 @@ const currentLang = computed(() => localeStore.getCurrentLocale)
 
 const setLang = (lang: LocaleType) => {
   if (lang === unref(currentLang).lang) return
-  // 需要重新加载页面让整个语言多初始化
-  window.location.reload()
-  localeStore.setCurrentLocale({
-    lang
-  })
   const { changeLocale } = useLocale()
   changeLocale(lang)
 }

--- a/src/components/LocaleDropdown/src/LocaleDropdown.vue
+++ b/src/components/LocaleDropdown/src/LocaleDropdown.vue
@@ -20,10 +20,14 @@ const langMap = computed(() => localeStore.getLocaleMap)
 
 const currentLang = computed(() => localeStore.getCurrentLocale)
 
-const setLang = (lang: LocaleType) => {
+const { changeLocale } = useLocale()
+
+const setLang = async (lang: LocaleType) => {
   if (lang === unref(currentLang).lang) return
-  const { changeLocale } = useLocale()
-  changeLocale(lang)
+  localeStore.setCurrentLocale({
+    lang
+  })
+  await changeLocale(lang)
 }
 </script>
 

--- a/src/hooks/web/useTitle.ts
+++ b/src/hooks/web/useTitle.ts
@@ -1,21 +1,23 @@
-import { watch, ref } from 'vue'
+import { watch, computed } from 'vue'
 import { isString } from '@/utils/is'
 import { useAppStoreWithOut } from '@/store/modules/app'
 import { useI18n } from '@/hooks/web/useI18n'
+import { useLocaleStore } from '@/store/modules/locale'
 
 export const useTitle = (newTitle?: string) => {
   const { t } = useI18n()
   const appStore = useAppStoreWithOut()
+  const localeStore = useLocaleStore()
 
-  const title = ref(
-    newTitle ? `${appStore.getTitle} - ${t(newTitle as string)}` : appStore.getTitle
-  )
+  const title = computed(() => {
+    return newTitle ? `${appStore.getTitle} - ${t(newTitle as string)}` : appStore.getTitle
+  })
 
   watch(
-    title,
-    (n, o) => {
-      if (isString(n) && n !== o && document) {
-        document.title = n
+    [title, () => localeStore.getCurrentLocale],
+    () => {
+      if (isString(title.value) && document) {
+        document.title = title.value
       }
     },
     { immediate: true }

--- a/src/hooks/web/useTitle.ts
+++ b/src/hooks/web/useTitle.ts
@@ -1,23 +1,21 @@
-import { watch, computed } from 'vue'
+import { watch, ref } from 'vue'
 import { isString } from '@/utils/is'
 import { useAppStoreWithOut } from '@/store/modules/app'
 import { useI18n } from '@/hooks/web/useI18n'
-import { useLocaleStore } from '@/store/modules/locale'
 
 export const useTitle = (newTitle?: string) => {
   const { t } = useI18n()
   const appStore = useAppStoreWithOut()
-  const localeStore = useLocaleStore()
 
-  const title = computed(() => {
-    return newTitle ? `${appStore.getTitle} - ${t(newTitle as string)}` : appStore.getTitle
-  })
+  const title = ref(
+    newTitle ? `${appStore.getTitle} - ${t(newTitle as string)}` : appStore.getTitle
+  )
 
   watch(
-    [title, () => localeStore.getCurrentLocale],
-    () => {
-      if (isString(title.value) && document) {
-        document.title = title.value
+    title,
+    (n, o) => {
+      if (isString(n) && n !== o && document) {
+        document.title = n
       }
     },
     { immediate: true }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,10 +2,7 @@ import { createRouter, createWebHashHistory } from 'vue-router'
 import type { RouteRecordRaw } from 'vue-router'
 import type { App } from 'vue'
 import { Layout, getParentLayout } from '@/utils/routerHelper'
-import { useI18n } from '@/hooks/web/useI18n'
 import { NO_RESET_WHITE_LIST } from '@/constants'
-
-const { t } = useI18n()
 
 export const constantRouterMap: AppRouteRecordRaw[] = [
   {
@@ -40,7 +37,7 @@ export const constantRouterMap: AppRouteRecordRaw[] = [
     name: 'Login',
     meta: {
       hidden: true,
-      title: t('router.login'),
+      title: 'router.login',
       noTagsView: true
     }
   },
@@ -50,7 +47,7 @@ export const constantRouterMap: AppRouteRecordRaw[] = [
     redirect: '/personal/personal-center',
     name: 'Personal',
     meta: {
-      title: t('router.personal'),
+      title: 'router.personal',
       hidden: true,
       canTo: true
     },
@@ -60,7 +57,7 @@ export const constantRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Personal/PersonalCenter/PersonalCenter.vue'),
         name: 'PersonalCenter',
         meta: {
-          title: t('router.personalCenter'),
+          title: 'router.personalCenter',
           hidden: true,
           canTo: true
         }
@@ -86,7 +83,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
     redirect: '/dashboard/analysis',
     name: 'Dashboard',
     meta: {
-      title: t('router.dashboard'),
+      title: 'router.dashboard',
       icon: 'vi-ant-design:dashboard-filled',
       alwaysShow: true
     },
@@ -96,7 +93,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Dashboard/Analysis.vue'),
         name: 'Analysis',
         meta: {
-          title: t('router.analysis'),
+          title: 'router.analysis',
           noCache: true,
           affix: true
         }
@@ -106,7 +103,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Dashboard/Workplace.vue'),
         name: 'Workplace',
         meta: {
-          title: t('router.workplace'),
+          title: 'router.workplace',
           noCache: true
         }
       }
@@ -122,7 +119,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         path: 'https://element-plus-admin-doc.cn/',
         name: 'DocumentLink',
         meta: {
-          title: t('router.document'),
+          title: 'router.document',
           icon: 'vi-clarity:document-solid'
         }
       }
@@ -139,7 +136,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Guide/Guide.vue'),
         name: 'GuideDemo',
         meta: {
-          title: t('router.guide'),
+          title: 'router.guide',
           icon: 'vi-cib:telegram-plane'
         }
       }
@@ -150,7 +147,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
     component: Layout,
     name: 'ComponentsDemo',
     meta: {
-      title: t('router.component'),
+      title: 'router.component',
       icon: 'vi-bx:bxs-component',
       alwaysShow: true
     },
@@ -161,7 +158,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         redirect: '/components/form/default-form',
         name: 'Form',
         meta: {
-          title: t('router.form'),
+          title: 'router.form',
           alwaysShow: true
         },
         children: [
@@ -170,7 +167,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
             component: () => import('@/views/Components/Form/DefaultForm.vue'),
             name: 'DefaultForm',
             meta: {
-              title: t('router.defaultForm')
+              title: 'router.defaultForm'
             }
           },
           {
@@ -189,7 +186,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         redirect: '/components/table/default-table',
         name: 'TableDemo',
         meta: {
-          title: t('router.table'),
+          title: 'router.table',
           alwaysShow: true
         },
         children: [
@@ -198,7 +195,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
             component: () => import('@/views/Components/Table/DefaultTable.vue'),
             name: 'DefaultTable',
             meta: {
-              title: t('router.defaultTable')
+              title: 'router.defaultTable'
             }
           },
           {
@@ -214,7 +211,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
             component: () => import('@/views/Components/Table/TreeTable.vue'),
             name: 'TreeTable',
             meta: {
-              title: t('router.treeTable')
+              title: 'router.treeTable'
             }
           },
           {
@@ -222,7 +219,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
             component: () => import('@/views/Components/Table/TableImagePreview.vue'),
             name: 'TableImagePreview',
             meta: {
-              title: t('router.PicturePreview')
+              title: 'router.PicturePreview'
             }
           },
           {
@@ -230,7 +227,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
             component: () => import('@/views/Components/Table/TableVideoPreview.vue'),
             name: 'TableVideoPreview',
             meta: {
-              title: t('router.tableVideoPreview')
+              title: 'router.tableVideoPreview'
             }
           },
           {
@@ -238,7 +235,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
             component: () => import('@/views/Components/Table/CardTable.vue'),
             name: 'CardTable',
             meta: {
-              title: t('router.cardTable')
+              title: 'router.cardTable'
             }
           }
         ]
@@ -249,7 +246,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         redirect: '/components/editor-demo/editor',
         name: 'EditorDemo',
         meta: {
-          title: t('router.editor'),
+          title: 'router.editor',
           alwaysShow: true
         },
         children: [
@@ -258,7 +255,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
             component: () => import('@/views/Components/Editor/Editor.vue'),
             name: 'Editor',
             meta: {
-              title: t('router.richText')
+              title: 'router.richText'
             }
           },
           {
@@ -266,7 +263,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
             component: () => import('@/views/Components/Editor/JsonEditor.vue'),
             name: 'JsonEditor',
             meta: {
-              title: t('router.jsonEditor')
+              title: 'router.jsonEditor'
             }
           }
         ]
@@ -276,7 +273,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/Search.vue'),
         name: 'Search',
         meta: {
-          title: t('router.search')
+          title: 'router.search'
         }
       },
       {
@@ -284,7 +281,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/Descriptions.vue'),
         name: 'Descriptions',
         meta: {
-          title: t('router.descriptions')
+          title: 'router.descriptions'
         }
       },
       {
@@ -292,7 +289,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/ImageViewer.vue'),
         name: 'ImageViewer',
         meta: {
-          title: t('router.imageViewer')
+          title: 'router.imageViewer'
         }
       },
       {
@@ -300,7 +297,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/Dialog.vue'),
         name: 'Dialog',
         meta: {
-          title: t('router.dialog')
+          title: 'router.dialog'
         }
       },
       {
@@ -308,7 +305,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/Icon.vue'),
         name: 'Icon',
         meta: {
-          title: t('router.icon')
+          title: 'router.icon'
         }
       },
       {
@@ -316,7 +313,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/IconPicker.vue'),
         name: 'IconPicker',
         meta: {
-          title: t('router.iconPicker')
+          title: 'router.iconPicker'
         }
       },
       {
@@ -324,7 +321,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/Echart.vue'),
         name: 'Echart',
         meta: {
-          title: t('router.echart')
+          title: 'router.echart'
         }
       },
       {
@@ -332,7 +329,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/CountTo.vue'),
         name: 'CountTo',
         meta: {
-          title: t('router.countTo')
+          title: 'router.countTo'
         }
       },
       {
@@ -340,7 +337,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/Qrcode.vue'),
         name: 'Qrcode',
         meta: {
-          title: t('router.qrcode')
+          title: 'router.qrcode'
         }
       },
       {
@@ -348,7 +345,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/Highlight.vue'),
         name: 'Highlight',
         meta: {
-          title: t('router.highlight')
+          title: 'router.highlight'
         }
       },
       {
@@ -356,7 +353,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/Infotip.vue'),
         name: 'Infotip',
         meta: {
-          title: t('router.infotip')
+          title: 'router.infotip'
         }
       },
       {
@@ -364,7 +361,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/InputPassword.vue'),
         name: 'InputPassword',
         meta: {
-          title: t('router.inputPassword')
+          title: 'router.inputPassword'
         }
       },
       {
@@ -372,7 +369,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/Waterfall.vue'),
         name: 'waterfall',
         meta: {
-          title: t('router.waterfall')
+          title: 'router.waterfall'
         }
       },
       {
@@ -380,7 +377,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/ImageCropping.vue'),
         name: 'ImageCropping',
         meta: {
-          title: t('router.imageCropping')
+          title: 'router.imageCropping'
         }
       },
       {
@@ -388,7 +385,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/VideoPlayer.vue'),
         name: 'VideoPlayer',
         meta: {
-          title: t('router.videoPlayer')
+          title: 'router.videoPlayer'
         }
       },
       {
@@ -396,7 +393,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/Avatars.vue'),
         name: 'Avatars',
         meta: {
-          title: t('router.avatars')
+          title: 'router.avatars'
         }
       },
       {
@@ -404,7 +401,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Components/IAgree.vue'),
         name: 'IAgree',
         meta: {
-          title: t('router.iAgree')
+          title: 'router.iAgree'
         }
       }
     ]
@@ -415,7 +412,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
     redirect: '/function/multipleTabs',
     name: 'Function',
     meta: {
-      title: t('router.function'),
+      title: 'router.function',
       icon: 'vi-ri:function-fill',
       alwaysShow: true
     },
@@ -425,7 +422,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Function/MultipleTabs.vue'),
         name: 'MultipleTabs',
         meta: {
-          title: t('router.multipleTabs')
+          title: 'router.multipleTabs'
         }
       },
       {
@@ -434,7 +431,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         name: 'MultipleTabsDemo',
         meta: {
           hidden: true,
-          title: t('router.details'),
+          title: 'router.details',
           canTo: true,
           activeMenu: '/function/multiple-tabs'
         }
@@ -444,7 +441,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Function/Request.vue'),
         name: 'Request',
         meta: {
-          title: t('router.request')
+          title: 'router.request'
         }
       },
       {
@@ -452,7 +449,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Function/Test.vue'),
         name: 'Test',
         meta: {
-          title: t('router.permission'),
+          title: 'router.permission',
           permission: ['add', 'edit', 'delete']
         }
       }
@@ -525,7 +522,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
     redirect: '/level/menu1/menu1-1/menu1-1-1',
     name: 'Level',
     meta: {
-      title: t('router.level'),
+      title: 'router.level',
       icon: 'vi-carbon:skill-level-advanced'
     },
     children: [
@@ -535,7 +532,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: getParentLayout(),
         redirect: '/level/menu1/menu1-1/menu1-1-1',
         meta: {
-          title: t('router.menu1')
+          title: 'router.menu1'
         },
         children: [
           {
@@ -544,7 +541,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
             component: getParentLayout(),
             redirect: '/level/menu1/menu1-1/menu1-1-1',
             meta: {
-              title: t('router.menu11'),
+              title: 'router.menu11',
               alwaysShow: true
             },
             children: [
@@ -553,7 +550,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
                 name: 'Menu111',
                 component: () => import('@/views/Level/Menu111.vue'),
                 meta: {
-                  title: t('router.menu111')
+                  title: 'router.menu111'
                 }
               }
             ]
@@ -563,7 +560,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
             name: 'Menu12',
             component: () => import('@/views/Level/Menu12.vue'),
             meta: {
-              title: t('router.menu12')
+              title: 'router.menu12'
             }
           }
         ]
@@ -573,7 +570,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         name: 'Menu2',
         component: () => import('@/views/Level/Menu2.vue'),
         meta: {
-          title: t('router.menu2')
+          title: 'router.menu2'
         }
       }
     ]
@@ -584,7 +581,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
     redirect: '/example/example-dialog',
     name: 'Example',
     meta: {
-      title: t('router.example'),
+      title: 'router.example',
       icon: 'vi-ep:management',
       alwaysShow: true
     },
@@ -594,7 +591,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Example/Dialog/ExampleDialog.vue'),
         name: 'ExampleDialog',
         meta: {
-          title: t('router.exampleDialog')
+          title: 'router.exampleDialog'
         }
       },
       {
@@ -602,7 +599,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Example/Page/ExamplePage.vue'),
         name: 'ExamplePage',
         meta: {
-          title: t('router.examplePage')
+          title: 'router.examplePage'
         }
       },
       {
@@ -610,7 +607,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Example/Page/ExampleAdd.vue'),
         name: 'ExampleAdd',
         meta: {
-          title: t('router.exampleAdd'),
+          title: 'router.exampleAdd',
           noTagsView: true,
           noCache: true,
           hidden: true,
@@ -623,7 +620,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Example/Page/ExampleEdit.vue'),
         name: 'ExampleEdit',
         meta: {
-          title: t('router.exampleEdit'),
+          title: 'router.exampleEdit',
           noTagsView: true,
           noCache: true,
           hidden: true,
@@ -636,7 +633,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Example/Page/ExampleDetail.vue'),
         name: 'ExampleDetail',
         meta: {
-          title: t('router.exampleDetail'),
+          title: 'router.exampleDetail',
           noTagsView: true,
           noCache: true,
           hidden: true,
@@ -652,7 +649,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
     redirect: '/error/404',
     name: 'Error',
     meta: {
-      title: t('router.errorPage'),
+      title: 'router.errorPage',
       icon: 'vi-ci:error',
       alwaysShow: true
     },
@@ -689,7 +686,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
     redirect: '/authorization/user',
     name: 'Authorization',
     meta: {
-      title: t('router.authorization'),
+      title: 'router.authorization',
       icon: 'vi-eos-icons:role-binding',
       alwaysShow: true
     },
@@ -699,7 +696,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Authorization/Department/Department.vue'),
         name: 'Department',
         meta: {
-          title: t('router.department')
+          title: 'router.department'
         }
       },
       {
@@ -707,7 +704,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Authorization/User/User.vue'),
         name: 'User',
         meta: {
-          title: t('router.user')
+          title: 'router.user'
         }
       },
       {
@@ -715,7 +712,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Authorization/Menu/Menu.vue'),
         name: 'Menu',
         meta: {
-          title: t('router.menuManagement')
+          title: 'router.menuManagement'
         }
       },
       {
@@ -723,7 +720,7 @@ export const asyncRouterMap: AppRouteRecordRaw[] = [
         component: () => import('@/views/Authorization/Role/Role.vue'),
         name: 'Role',
         meta: {
-          title: t('router.role')
+          title: 'router.role'
         }
       }
     ]


### PR DESCRIPTION
语言切换是无刷新的。
菜单标题会跟着切换中英文。
已打开的标签页标题也会跟着切换中英文。
代码层面LocaleDropdown.vue已经改成直接切语言，不再靠整页刷新；路由里的meta.title也改成了翻译 key